### PR TITLE
Screenshot

### DIFF
--- a/InstaTech_Client/InstaTech_Client.csproj
+++ b/InstaTech_Client/InstaTech_Client.csproj
@@ -116,6 +116,7 @@
     <Compile Include="AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ScreenShot.cs" />
     <Compile Include="UnattendedWindow.xaml.cs">
       <DependentUpon>UnattendedWindow.xaml</DependentUpon>
     </Compile>

--- a/InstaTech_Client/MainWindow.xaml.cs
+++ b/InstaTech_Client/MainWindow.xaml.cs
@@ -84,7 +84,7 @@ namespace InstaTech_Client
             screenShot.Initialize();
             offsetX = SystemInformation.VirtualScreen.Left;
             offsetY = SystemInformation.VirtualScreen.Top;
-            Graphic = Graphics.FromImage(screenShot.Screenshot);
+            Graphic = Graphics.FromImage(screenShot.CurrentFrame);
 
             // Clean up temp files from previous file transfers.
             var di = new DirectoryInfo(System.IO.Path.GetTempPath() + @"\InstaTech");
@@ -615,7 +615,7 @@ namespace InstaTech_Client
                     await SocketSend(request);
                     using (var ms = new MemoryStream())
                     {
-                        screenShot.Screenshot.Save(ms, ImageFormat.Jpeg);
+                        screenShot.CurrentFrame.Save(ms, ImageFormat.Jpeg);
                         ms.WriteByte(0);
                         ms.WriteByte(0);
                         ms.WriteByte(0);

--- a/InstaTech_Client/ScreenShot.cs
+++ b/InstaTech_Client/ScreenShot.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace InstaTech_Client
+{
+    public class ScreenShot
+    {
+        private Bitmap _lastFrame;
+        private Rectangle _boundingBox;
+
+        public Bitmap Screenshot { get; private set; }
+        public int TotalHeight { get; private set; } = 0;
+        public int TotalWidth { get; private set; } = 0;
+
+        public void Initialize()
+        {
+            TotalWidth = SystemInformation.VirtualScreen.Width;
+            TotalHeight = SystemInformation.VirtualScreen.Height;
+            Screenshot = new Bitmap(TotalWidth, TotalHeight);
+            _lastFrame = new Bitmap(TotalWidth, TotalHeight);
+        }
+
+        public void SaveCroppedFrame(MemoryStream ms)
+        {
+            var croppedFrame = Screenshot.Clone(_boundingBox, PixelFormat.Format32bppArgb);
+            croppedFrame.Save(ms, ImageFormat.Jpeg);
+        }
+
+        public void CloneLastFrame()
+        {
+            _lastFrame = (Bitmap)Screenshot.Clone();
+        }
+
+        public byte[] GetNewData()
+        {
+            return GetChangedPixels(Screenshot, _lastFrame);
+        }
+
+        private byte[] GetChangedPixels(Bitmap bitmap1, Bitmap bitmap2)
+        {
+            if (bitmap1.Height != bitmap2.Height || bitmap1.Width != bitmap2.Width)
+            {
+                throw new Exception("Bitmaps are not of equal dimensions.");
+            }
+            if (!Bitmap.IsAlphaPixelFormat(bitmap1.PixelFormat) || !Bitmap.IsAlphaPixelFormat(bitmap2.PixelFormat) ||
+                !Bitmap.IsCanonicalPixelFormat(bitmap1.PixelFormat) || !Bitmap.IsCanonicalPixelFormat(bitmap2.PixelFormat))
+            {
+                throw new Exception("Bitmaps must be 32 bits per pixel and contain alpha channel.");
+            }
+            var width = bitmap1.Width;
+            var height = bitmap1.Height;
+            byte[] newImgData;
+            int left = int.MaxValue;
+            int top = int.MaxValue;
+            int right = int.MinValue;
+            int bottom = int.MinValue;
+
+            var bd1 = bitmap1.LockBits(new System.Drawing.Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, bitmap1.PixelFormat);
+            var bd2 = bitmap2.LockBits(new System.Drawing.Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, bitmap2.PixelFormat);
+            // Get the address of the first line.
+            IntPtr ptr1 = bd1.Scan0;
+            IntPtr ptr2 = bd2.Scan0;
+
+            // Declare an array to hold the bytes of the bitmap.
+            int bytes = Math.Abs(bd1.Stride) * Screenshot.Height;
+            byte[] rgbValues1 = new byte[bytes];
+            byte[] rgbValues2 = new byte[bytes];
+
+            // Copy the RGBA values into the array.
+            Marshal.Copy(ptr1, rgbValues1, 0, bytes);
+            Marshal.Copy(ptr2, rgbValues2, 0, bytes);
+
+            // Check RGBA value for each pixel.
+            for (int counter = 0; counter < rgbValues1.Length - 4; counter += 4)
+            {
+                if (rgbValues1[counter] != rgbValues2[counter] ||
+                    rgbValues1[counter + 1] != rgbValues2[counter + 1] ||
+                    rgbValues1[counter + 2] != rgbValues2[counter + 2] ||
+                    rgbValues1[counter + 3] != rgbValues2[counter + 3])
+                {
+                    // Change was found.
+                    var pixel = counter / 4;
+                    var row = (int)Math.Floor((double)pixel / bd1.Width);
+                    var column = pixel % bd1.Width;
+                    if (row < top)
+                    {
+                        top = row;
+                    }
+                    if (row > bottom)
+                    {
+                        bottom = row;
+                    }
+                    if (column < left)
+                    {
+                        left = column;
+                    }
+                    if (column > right)
+                    {
+                        right = column;
+                    }
+                }
+            }
+            if (left < right && top < bottom)
+            {
+                // Bounding box is valid.
+
+                left = Math.Max(left - 20, 0);
+                top = Math.Max(top - 20, 0);
+                right = Math.Min(right + 20, TotalWidth);
+                bottom = Math.Min(bottom + 20, TotalHeight);
+
+                // Byte array that indicates top left coordinates of the image.
+                newImgData = new byte[6];
+                newImgData[0] = Byte.Parse(left.ToString().PadLeft(6, '0').Substring(0, 2));
+                newImgData[1] = Byte.Parse(left.ToString().PadLeft(6, '0').Substring(2, 2));
+                newImgData[2] = Byte.Parse(left.ToString().PadLeft(6, '0').Substring(4, 2));
+                newImgData[3] = Byte.Parse(top.ToString().PadLeft(6, '0').Substring(0, 2));
+                newImgData[4] = Byte.Parse(top.ToString().PadLeft(6, '0').Substring(2, 2));
+                newImgData[5] = Byte.Parse(top.ToString().PadLeft(6, '0').Substring(4, 2));
+
+                _boundingBox = new System.Drawing.Rectangle(left, top, right - left, bottom - top);
+                bitmap1.UnlockBits(bd1);
+                bitmap2.UnlockBits(bd2);
+                return newImgData;
+            }
+            else
+            {
+                bitmap1.UnlockBits(bd1);
+                bitmap2.UnlockBits(bd2);
+                return null;
+            }
+        }
+    }
+}

--- a/InstaTech_Client/ScreenShot.cs
+++ b/InstaTech_Client/ScreenShot.cs
@@ -28,8 +28,10 @@ namespace InstaTech_Client
 
         public void SaveCroppedFrame(MemoryStream ms)
         {
-            var croppedFrame = _currentFrame.Clone(_boundingBox, PixelFormat.Format32bppArgb);
-            croppedFrame.Save(ms, ImageFormat.Jpeg);
+            using (var croppedFrame = _currentFrame.Clone(_boundingBox, PixelFormat.Format32bppArgb))
+            {
+                croppedFrame.Save(ms, ImageFormat.Jpeg);
+            }
         }
 
         public void CloneLastFrame()

--- a/InstaTech_Client/ScreenShot.cs
+++ b/InstaTech_Client/ScreenShot.cs
@@ -37,30 +37,25 @@ namespace InstaTech_Client
 
         public byte[] GetNewData()
         {
-            return GetChangedPixels(Screenshot, _lastFrame);
-        }
-
-        private byte[] GetChangedPixels(Bitmap bitmap1, Bitmap bitmap2)
-        {
-            if (bitmap1.Height != bitmap2.Height || bitmap1.Width != bitmap2.Width)
+            if (Screenshot.Height != _lastFrame.Height || Screenshot.Width != _lastFrame.Width)
             {
                 throw new Exception("Bitmaps are not of equal dimensions.");
             }
-            if (!Bitmap.IsAlphaPixelFormat(bitmap1.PixelFormat) || !Bitmap.IsAlphaPixelFormat(bitmap2.PixelFormat) ||
-                !Bitmap.IsCanonicalPixelFormat(bitmap1.PixelFormat) || !Bitmap.IsCanonicalPixelFormat(bitmap2.PixelFormat))
+            if (!Bitmap.IsAlphaPixelFormat(Screenshot.PixelFormat) || !Bitmap.IsAlphaPixelFormat(_lastFrame.PixelFormat) ||
+                !Bitmap.IsCanonicalPixelFormat(Screenshot.PixelFormat) || !Bitmap.IsCanonicalPixelFormat(_lastFrame.PixelFormat))
             {
                 throw new Exception("Bitmaps must be 32 bits per pixel and contain alpha channel.");
             }
-            var width = bitmap1.Width;
-            var height = bitmap1.Height;
+            var width = Screenshot.Width;
+            var height = Screenshot.Height;
             byte[] newImgData;
             int left = int.MaxValue;
             int top = int.MaxValue;
             int right = int.MinValue;
             int bottom = int.MinValue;
 
-            var bd1 = bitmap1.LockBits(new System.Drawing.Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, bitmap1.PixelFormat);
-            var bd2 = bitmap2.LockBits(new System.Drawing.Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, bitmap2.PixelFormat);
+            var bd1 = Screenshot.LockBits(new System.Drawing.Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, Screenshot.PixelFormat);
+            var bd2 = _lastFrame.LockBits(new System.Drawing.Rectangle(0, 0, width, height), ImageLockMode.ReadOnly, _lastFrame.PixelFormat);
             // Get the address of the first line.
             IntPtr ptr1 = bd1.Scan0;
             IntPtr ptr2 = bd2.Scan0;
@@ -123,14 +118,14 @@ namespace InstaTech_Client
                 newImgData[5] = Byte.Parse(top.ToString().PadLeft(6, '0').Substring(4, 2));
 
                 _boundingBox = new System.Drawing.Rectangle(left, top, right - left, bottom - top);
-                bitmap1.UnlockBits(bd1);
-                bitmap2.UnlockBits(bd2);
+                Screenshot.UnlockBits(bd1);
+                _lastFrame.UnlockBits(bd2);
                 return newImgData;
             }
             else
             {
-                bitmap1.UnlockBits(bd1);
-                bitmap2.UnlockBits(bd2);
+                Screenshot.UnlockBits(bd1);
+                _lastFrame.UnlockBits(bd2);
                 return null;
             }
         }


### PR DESCRIPTION
I extracted a class from the client's main window. It contains all of the information and code related to the screen shots. This should make it easier to keep your code organized.

I followed a naming convention of naming fields with underscores. I exposed one of the fields through a read-only property so that the main window could get to it. And the height and width I made auto properties with private setters, so that they could not be changed by the main window.

I also found a place where a bitmap was not disposed. I think this would have consumed more and more memory until the client eventualy ran out. Have you noticed any problems like that?